### PR TITLE
Add stats page based on tweet id

### DIFF
--- a/tweets_on_trial/app/urls.py
+++ b/tweets_on_trial/app/urls.py
@@ -8,6 +8,7 @@ app_name = 'app'
 urlpatterns = [
     path('', views.index, name='index'),
     path('judge/', views.judge, name='judge'),
+    path('stats/<tweet_id>/', views.stats, name = 'stats'),
     path('register/', views.register, name='register'),
     path('login/', views.user_login, name='login'),
     path('logout/', views.user_logout, name='logout',)

--- a/tweets_on_trial/app/views.py
+++ b/tweets_on_trial/app/views.py
@@ -42,6 +42,18 @@ def judge(request):
     context_dict['tweet'] = tweet
     return render(request, 'app/judgement.html', context=context_dict)
 
+def stats(request, tweet_id):
+    try:
+        tweet = Tweet.objects.get(id=tweet_id)
+        results = TweetResults.objects.get(id=tweet_id)
+        context_dict = {}
+        context_dict['tweet'] = tweet
+        context_dict['results'] = results
+        return render(request, 'app/stats.html', context=context_dict)
+    except Tweet.DoesNotExist:
+        return HttpResponse("Tweet statistics not found")
+
+
 def register(request):
     registered = False
     if request.method == 'POST':

--- a/tweets_on_trial/templates/app/judgement.html
+++ b/tweets_on_trial/templates/app/judgement.html
@@ -29,6 +29,9 @@
             <button class="btn" id="down" type="button" name="up_btn" style="color: white;" value="Skip">Skip</button>
         </form>
     </div>
+    {% if tweet %}
+        <p style="text-align:center;"><a href="{% url 'app:stats' tweet.id %}" class="btn">Go to tweet global results</a></p>
+    {% endif %}
     <footer class="page-footer font-small blue pt-4 bg-primary">
         <div class="footer-copyright text-center py-3" style="color: white;">
             Tweets on Trial

--- a/tweets_on_trial/templates/app/stats.html
+++ b/tweets_on_trial/templates/app/stats.html
@@ -1,0 +1,19 @@
+{% extends 'app/base.html' %}
+{% load static %} 
+{% block body_block %}
+
+    {% if tweet %}
+        <p>{{ tweet.body }}</p>
+    {% else %}
+        <p>No tweet found</p>
+    {% endif %}
+
+    {% if results %}
+        <p>{{ results.sum }} have voted on this tweet</p>
+    {% else %}
+        <p>No results found</p>
+    {% endif %}
+    
+    <a href="{% url 'app:judge' %}" class="btn">Judge next tweet</a>
+    
+{% endblock %}


### PR DESCRIPTION
app/stats/id shows tweet data - placeholder for graphs
also contains a url that maps to judge page to load next tweet

judge page now contains url to tweet stats - placeholder

Signed-off-by: JoeSubbi <joe.subbiani@gmail.com>